### PR TITLE
Renamed JSONCPP_STACK_LIMIT to JSONCPP_DEPRECATED_STACK_LIMIT

### DIFF
--- a/src/lib_json/json_reader.cpp
+++ b/src/lib_json/json_reader.cpp
@@ -45,12 +45,12 @@
 #pragma warning(disable : 4996)
 #endif
 
-// Define JSONCPP_STACK_LIMIT as an appropriate integer at compile time to change the stack limit
-#if !defined(JSONCPP_STACK_LIMIT)
-#define JSONCPP_STACK_LIMIT 1000
+// Define JSONCPP_DEPRECATED_STACK_LIMIT as an appropriate integer at compile time to change the stack limit
+#if !defined(JSONCPP_DEPRECATED_STACK_LIMIT)
+#define JSONCPP_DEPRECATED_STACK_LIMIT 1000
 #endif
 
-static size_t const stackLimit_g = JSONCPP_STACK_LIMIT; // see readValue()
+static size_t const stackLimit_g = JSONCPP_DEPRECATED_STACK_LIMIT; // see readValue()
 
 namespace Json {
 


### PR DESCRIPTION
Renamed JSONCPP_STACK_LIMIT to JSONCPP_DEPRECATED_STACK_LIMIT to stress that usage of this macros assumes old interface.